### PR TITLE
Error Handling Correction in barte-python-sdk

### DIFF
--- a/barte/client.py
+++ b/barte/client.py
@@ -111,8 +111,7 @@ class BarteClient:
             )
             error_response.raise_exception(response=response)
 
-        if not response.ok:
-            response.raise_for_status()
+        response.raise_for_status()
 
         return json_response
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,11 +4,11 @@ from unittest.mock import Mock, patch
 
 import pytest
 from dacite import from_dict
+from requests.exceptions import HTTPError
 
 from barte import BarteClient, CardToken, Charge, PartialRefund, PixCharge
 from barte.exceptions import BarteError
 from barte.models import DACITE_CONFIG, InstallmentOption, Order
-
 
 @pytest.fixture
 def barte_client():
@@ -819,8 +819,6 @@ class TestBarteClient:
         self, mock_request, barte_client
     ):
         """Test _request raises HTTPError when API returns HTTP error without structured error body"""
-        from requests.exceptions import HTTPError
-
         mock_response = Mock()
         mock_response.status_code = 500
         mock_response.ok = False
@@ -834,8 +832,6 @@ class TestBarteClient:
     @patch("barte.client.requests.Session.request")
     def test_request_raises_http_error_on_invalid_json(self, mock_request, barte_client):
         """Test _request raises HTTPError when response is not valid JSON"""
-        from requests.exceptions import HTTPError
-
         mock_response = Mock()
         mock_response.status_code = 500
         mock_response.json.side_effect = ValueError("No JSON object could be decoded")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -10,6 +10,7 @@ from barte import BarteClient, CardToken, Charge, PartialRefund, PixCharge
 from barte.exceptions import BarteError
 from barte.models import DACITE_CONFIG, InstallmentOption, Order
 
+
 @pytest.fixture
 def barte_client():
     client = BarteClient(api_key="test_key", environment="sandbox")
@@ -830,7 +831,9 @@ class TestBarteClient:
             barte_client._request("GET", "/v2/orders")
 
     @patch("barte.client.requests.Session.request")
-    def test_request_raises_http_error_on_invalid_json(self, mock_request, barte_client):
+    def test_request_raises_http_error_on_invalid_json(
+        self, mock_request, barte_client
+    ):
         """Test _request raises HTTPError when response is not valid JSON"""
         mock_response = Mock()
         mock_response.status_code = 500


### PR DESCRIPTION
## Problema Identificado

O método `_request` em `client.py` chama `response.raise_for_status()` antes de processar o corpo da resposta. Quando a API retorna um erro HTTP (4xx/5xx), o `raise_for_status()` lança uma exceção `requests.exceptions.HTTPError` genérica, impedindo que:

* O `response.json()` seja chamado
* O erro seja parseado para `ErrorResponse`
* O `BarteError` "rico em contexto" seja lançado

Resultado: Usuários recebem `HTTPError` genérico ao invés de `BarteError` com informações úteis (code, action, charge_uuid).

## Resumo das mudanças

Arquivo modificado: `client.py`

### 1. Método `_request`
* Removido o `raise_for_status()` prematuro que suprimia os erros da API
* Agora primeiro tenta parsear o JSON da resposta
* Verifica se contém "errors" e lança BarteError com informações detalhadas
* Usa `raise_for_status()` apenas como fallback para erros sem corpo estruturado

### 2. Remoção de código duplicado

* Removido bloco de verificação de erros (agora centralizado) dos métodos: `create_order`, `refund_charge` e `partial_refund_charge`

Agora quando a API retorna um erro, você receberá um `BarteError` com todas as informações:
code: código do erro (ex: "BAR-7005")
* `message`: descrição do erro
* `action`: ação recomendada
* `charge_uuid`: UUID da cobrança relacionada (quando aplicável)
* `response`: objeto de resposta completo