### PR TITLE
Unifica github release step

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -98,15 +98,6 @@ jobs:
         run: >-
           gh release create
           '${{ github.ref_name }}'
+          dist/**
           --repo '${{ github.repository }}'
           --notes ""
-      - name: Upload artifact signatures to GitHub Release
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        # Upload to GitHub Release using the `gh` CLI.
-        # `dist/` contains the built packages, and the
-        # sigstore-produced signatures and certificates.
-        run: >-
-          gh release upload
-          '${{ github.ref_name }}' dist/**
-          --repo '${{ github.repository }}'


### PR DESCRIPTION
## Context

The release workflow was failing due to GitHub release immutability constraints. The previous implementation created the release first and uploaded artifacts in a separate step afterward.

Previous flow:

1. Create GitHub release
2. Upload generated artifacts (`dist/**`)

With immutable releases enabled, modifying a release after creation can fail (`HTTP 422`), causing the workflow to break.

## Changes

Updated the release workflow to upload artifacts during release creation instead of using a separate upload step.

Before:

```yaml
gh release create <tag>
gh release upload <tag> dist/**